### PR TITLE
Enhanced configuration and tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM alpine:${ALPINE_VERSION}
 
 COPY --from=builder /nanomq/build/nanomq/nanomq /usr/local/nanomq/
 COPY --from=builder /nanomq/build/nanomq_cli/nanomq_cli /usr/local/nanomq/
-COPY --from=builder /nanomq/etc/nanomq.conf /etc/nanomq.conf
+COPY ./nanomq.conf /etc/nanomq/nanomq.conf
 COPY --from=builder /nanomq/deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 
 WORKDIR /usr/local/nanomq
@@ -40,7 +40,9 @@ RUN set -x && \
 
 EXPOSE 1883 8883
 
+VOLUME /var/log/nanomq
+
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
-CMD ["--conf", "/etc/nanomq.conf"]
+CMD ["--conf", "/etc/nanomq/nanomq.conf"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,13 @@ RUN ln -s /usr/local/nanomq/nanomq /usr/bin/nanomq && \
     ln -s /usr/local/nanomq/nanomq_cli /usr/bin/nanomq_cli
 
 RUN set -x && \
-    apk --no-cache add mbedtls-dev libatomic
+    apk --no-cache add tini mbedtls-dev libatomic
 
 EXPOSE 1883 8883
 
 VOLUME /var/log/nanomq
 
-ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/docker-entrypoint.sh"]
 
 CMD ["--conf", "/etc/nanomq/nanomq.conf"]
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This is a custom build of the `eqmx/nanomq` docker image.  It is built
 with support for TLS/SSL only, and therefore falls between the
 "basic" and the "slim" versions as described in the [NanoMQ website].
 
+Other differences between this image and the the official docker image
+are set out below.
+
+## Mount points and volumes
+
+The configuration directory has been changed to `/etc/nanomq`.  This can be
+used as a docker mount point to load custom configurations.
+
+The default configuration will write logs to a docker volume mounted on
+`/var/log/nanomq`.
+
 ## Deployment
 
 See the [NanoMQ website] for deployment instructions.

--- a/nanomq.conf
+++ b/nanomq.conf
@@ -1,0 +1,71 @@
+# NanoMQ Configuration 0.18.0
+
+# #============================================================
+# # NanoMQ Broker
+# #============================================================
+
+mqtt {
+    property_size = 32
+    max_packet_size = 10KB
+    max_mqueue_len = 2048
+    retry_interval = 10s
+    keepalive_multiplier = 1.25
+    
+    # Three of below, unsupported now
+    max_inflight_window = 2048
+    max_awaiting_rel = 10s
+    await_rel_timeout = 10s
+}
+
+listeners.tcp {
+    bind = "0.0.0.0:1883"
+}
+
+# listeners.ssl {
+# 	bind = "0.0.0.0:8883"
+# 	keyfile = "/etc/nanomq/certs/key.pem"
+# 	certfile = "/etc/nanomq/certs/cert.pem"
+# 	cacertfile = "/etc/nanomq/certs/cacert.pem"
+# 	verify_peer = false
+# 	fail_if_no_peer_cert = false
+# }
+
+listeners.ws {
+    bind = "0.0.0.0:8083/mqtt"
+}
+
+http_server {
+    port = 8081
+    limit_conn = 2
+    username = admin
+    password = public
+    auth_type = basic
+    jwt {
+        public.keyfile = "/etc/nanomq/certs/jwt/jwtRS256.key.pub"
+    }
+}
+
+log {
+    to = [file, console]
+    level = warn
+    dir = "/var/log/nanomq"
+    file = "nanomq.log"
+    rotation {
+        size = 10MB
+        count = 5
+    }
+}
+
+auth {
+    allow_anonymous = true
+    no_match = allow
+    deny_action = ignore
+    
+    cache = {
+        max_size = 32
+        ttl = 1m
+    }
+    
+    # password = {include "/etc/nanomq/nanomq_pwd.conf"}
+    # acl = {include "/etc/nanomq/nanomq_acl.conf"}
+}


### PR DESCRIPTION
Changes to the official docker image:

* Moved configuration directory to `/etc/nanomq`
* Added [tini] to supervise (just in case)

[tini]: https://github.com/krallin/tini?tab=readme-ov-file